### PR TITLE
Add Swagger documentation and service test

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ AnimeAI é uma aplicação Spring Boot que combina uma API REST, páginas Thymel
 - [▶️ Executando o Projeto](#️-executando-o-projeto)
 - [🔐 Variáveis de Ambiente](#-variáveis-de-ambiente)
 - [🛰️ Endpoints REST](#️-endpoints-rest)
+- [📘 Swagger / OpenAPI](#-swagger--openapi)
 - [🖥️ Interface Web](#️-interface-web)
 - [🧪 Testes](#-testes)
 - [🚀 Próximos Passos](#-próximos-passos)
@@ -74,6 +75,7 @@ AnimeAI/
 Depois que a aplicação subir:
 - Acesse `http://localhost:8080/animes` para a interface web.
 - A API REST estará disponível sob `http://localhost:8080/anime`.
+- A documentação Swagger pode ser consultada em `http://localhost:8080/swagger-ui.html`.
 - O console do H2 pode ser aberto em `http://localhost:8080/h2` (JDBC URL: `jdbc:h2:file:./data/anime-db`).
 
 Para encerrar, pressione `Ctrl + C` no terminal.
@@ -126,6 +128,11 @@ Content-Type: application/json
 2. "Demon Slayer" entrega ação frenética e estética impecável.
 ```
 *(O resultado final depende do catálogo cadastrado e da resposta do modelo da OpenAI.)*
+
+## 📘 Swagger / OpenAPI
+- A documentação interativa pode ser acessada em [`http://localhost:8080/swagger-ui.html`](http://localhost:8080/swagger-ui.html).
+- O contrato OpenAPI em formato JSON está disponível em [`http://localhost:8080/v3/api-docs`](http://localhost:8080/v3/api-docs).
+- Sempre que novos endpoints forem adicionados, utilize as anotações do SpringDoc para mantê-los documentados automaticamente.
 
 ## 🖥️ Interface Web
 - `/animes` — lista paginada com alertas de sucesso/erro e ações para editar/excluir.

--- a/pom.xml
+++ b/pom.xml
@@ -38,19 +38,24 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webflux</artifactId>
-		</dependency>
-        <dependency>
-            <groupId>me.paulschwarz</groupId>
-            <artifactId>spring-dotenv</artifactId>
-            <version>3.0.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-thymeleaf</artifactId>
-        </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-webflux</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springdoc</groupId>
+                        <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+                        <version>2.6.0</version>
+                </dependency>
+                <dependency>
+                        <groupId>me.paulschwarz</groupId>
+                        <artifactId>spring-dotenv</artifactId>
+                        <version>3.0.0</version>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-thymeleaf</artifactId>
+                </dependency>
 		<dependency>
 			<groupId>org.flywaydb</groupId>
 			<artifactId>flyway-core</artifactId>

--- a/src/main/java/com/example/AnimeAI/config/OpenApiConfig.java
+++ b/src/main/java/com/example/AnimeAI/config/OpenApiConfig.java
@@ -1,0 +1,33 @@
+package com.example.AnimeAI.config;
+
+import io.swagger.v3.oas.models.ExternalDocumentation;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI animeAiOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("AnimeAI API")
+                        .description("API para gerenciar animes e obter sugestões alimentadas pela OpenAI.")
+                        .version("v1")
+                        .contact(new Contact()
+                                .name("AnimeAI Team")
+                                .url("https://github.com")
+                                .email("contato@animeai.example"))
+                        .license(new License()
+                                .name("Apache 2.0")
+                                .url("https://www.apache.org/licenses/LICENSE-2.0.html")))
+                .externalDocs(new ExternalDocumentation()
+                        .description("Repositório do projeto")
+                        .url("https://github.com/seu-usuario/AnimeAI"));
+    }
+}
+

--- a/src/main/java/com/example/AnimeAI/controller/AnimeController.java
+++ b/src/main/java/com/example/AnimeAI/controller/AnimeController.java
@@ -3,6 +3,13 @@ package com.example.AnimeAI.controller;
 import com.example.AnimeAI.model.AnimeModel;
 import com.example.AnimeAI.model.Categoria;
 import com.example.AnimeAI.service.AnimeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -13,6 +20,7 @@ import java.util.Optional;
 
 @RestController
 @RequestMapping("/anime")
+@Tag(name = "Animes", description = "Operações de gerenciamento do catálogo de animes")
 public class AnimeController {
 
     private final AnimeService animeService;
@@ -22,32 +30,68 @@ public class AnimeController {
     }
 
     @GetMapping
-    public ResponseEntity<List<AnimeModel>> findaAll(){
+    @Operation(summary = "Listar todos os animes", description = "Retorna a lista completa de animes cadastrados")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Animes retornados com sucesso",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = AnimeModel.class)))
+    })
+    public ResponseEntity<List<AnimeModel>> findAll(){
         List<AnimeModel> animes = animeService.findAll();
         return ResponseEntity.ok(animes);
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<AnimeModel> findById(@PathVariable Long id){
+    @Operation(summary = "Buscar anime por ID", description = "Recupera um anime específico usando o identificador")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Anime encontrado",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = AnimeModel.class))),
+            @ApiResponse(responseCode = "404", description = "Anime não encontrado", content = @Content)
+    })
+    public ResponseEntity<AnimeModel> findById(@Parameter(description = "Identificador único do anime", example = "1")
+                                               @PathVariable Long id){
         Optional<AnimeModel> anime = animeService.findById(id);
         return anime.map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }
 
     @GetMapping("/titulo/{titulo}")
-    public ResponseEntity<AnimeModel> findByTitulo(@PathVariable String titulo) {
+    @Operation(summary = "Buscar anime por título", description = "Retorna o anime que possui o título informado")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Anime encontrado",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = AnimeModel.class))),
+            @ApiResponse(responseCode = "404", description = "Anime não encontrado", content = @Content)
+    })
+    public ResponseEntity<AnimeModel> findByTitulo(@Parameter(description = "Título completo do anime", example = "Naruto")
+                                                   @PathVariable String titulo) {
         Optional<AnimeModel> anime = animeService.findByTitulo(titulo);
         return anime.map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }
 
     @GetMapping("/categoria/{categoria}")
-    public ResponseEntity<List<AnimeModel>> findByCategorias(@PathVariable Categoria categoria) {
+    @Operation(summary = "Listar por categoria", description = "Filtra os animes pela categoria informada")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Lista de animes da categoria",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = AnimeModel.class)))
+    })
+    public ResponseEntity<List<AnimeModel>> findByCategorias(@Parameter(description = "Categoria do anime", example = "SHOUNEN")
+                                                             @PathVariable Categoria categoria) {
         List<AnimeModel> anime = animeService.findByCategoria(categoria);
         return ResponseEntity.ok(anime);
     }
 
     @PostMapping
+    @Operation(summary = "Criar um novo anime", description = "Persiste um novo anime no catálogo")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Anime criado",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = AnimeModel.class))),
+            @ApiResponse(responseCode = "400", description = "Requisição inválida", content = @Content)
+    })
     public ResponseEntity<AnimeModel> save(@Validated @RequestBody AnimeModel anime) {
         try {
             AnimeModel animeSalvo = animeService.save(anime);
@@ -58,14 +102,29 @@ public class AnimeController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<AnimeModel> updateById(@PathVariable Long id, @Validated @RequestBody AnimeModel anime) {
+    @Operation(summary = "Atualizar anime", description = "Atualiza os dados de um anime existente")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Anime atualizado",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = AnimeModel.class))),
+            @ApiResponse(responseCode = "404", description = "Anime não encontrado", content = @Content)
+    })
+    public ResponseEntity<AnimeModel> updateById(@Parameter(description = "Identificador do anime", example = "1")
+                                                 @PathVariable Long id,
+                                                 @Validated @RequestBody AnimeModel anime) {
         Optional<AnimeModel> animeAtualizado = animeService.updateById(id, anime);
         return animeAtualizado.map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteById(@PathVariable Long id) {
+    @Operation(summary = "Remover anime", description = "Exclui um anime do catálogo a partir do identificador")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Anime removido", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Anime não encontrado", content = @Content)
+    })
+    public ResponseEntity<Void> deleteById(@Parameter(description = "Identificador do anime", example = "1")
+                                           @PathVariable Long id) {
         if (animeService.deleteById(id)) {
             return ResponseEntity.noContent().build();
         }

--- a/src/main/java/com/example/AnimeAI/controller/SuggestionAnimeController.java
+++ b/src/main/java/com/example/AnimeAI/controller/SuggestionAnimeController.java
@@ -3,6 +3,12 @@ package com.example.AnimeAI.controller;
 import com.example.AnimeAI.model.AnimeModel;
 import com.example.AnimeAI.service.AnimeService;
 import com.example.AnimeAI.service.OpenAIService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -13,9 +19,10 @@ import reactor.core.publisher.Mono;
 import java.util.List;
 
 @RestController
+@Tag(name = "Sugestões", description = "Endpoints que utilizam a OpenAI para gerar recomendações")
 public class SuggestionAnimeController {
 
-    private AnimeService service;
+    private final AnimeService service;
     private final OpenAIService openAIService;
 
     public SuggestionAnimeController(OpenAIService openAIService, AnimeService service) {
@@ -24,6 +31,13 @@ public class SuggestionAnimeController {
     }
 
     @GetMapping(value = "/suggestion", produces = MediaType.TEXT_PLAIN_VALUE)
+    @Operation(summary = "Sugestão de animes", description = "Gera recomendações em texto simples a partir do catálogo atual")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Sugestões retornadas com sucesso",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN_VALUE,
+                            schema = @Schema(implementation = String.class))),
+            @ApiResponse(responseCode = "502", description = "Erro ao consultar a OpenAI", content = @Content)
+    })
     public Mono<ResponseEntity<String>> suggestionAnime() {
         List<AnimeModel> animeModels = service.findAll();
         return openAIService.suggestionAnime(animeModels)

--- a/src/test/java/com/example/AnimeAI/service/AnimeServiceTest.java
+++ b/src/test/java/com/example/AnimeAI/service/AnimeServiceTest.java
@@ -1,0 +1,41 @@
+package com.example.AnimeAI.service;
+
+import com.example.AnimeAI.model.AnimeModel;
+import com.example.AnimeAI.model.Categoria;
+import com.example.AnimeAI.repository.AnimeRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AnimeServiceTest {
+
+    @Mock
+    private AnimeRepository animeRepository;
+
+    @InjectMocks
+    private AnimeService animeService;
+
+    @Test
+    void findAllShouldReturnRepositoryResult() {
+        List<AnimeModel> expected = List.of(
+                new AnimeModel(1L, "Naruto", Categoria.SHOUNEN, LocalDate.of(2002, 10, 3), 220)
+        );
+
+        when(animeRepository.findAll()).thenReturn(expected);
+
+        List<AnimeModel> result = animeService.findAll();
+
+        assertEquals(expected, result);
+        verify(animeRepository).findAll();
+    }
+}


### PR DESCRIPTION
## Summary
- add SpringDoc OpenAPI dependency and configuration to expose Swagger UI
- annotate REST controllers with OpenAPI metadata for full API documentation
- create a basic AnimeService unit test and document Swagger access in the README

## Testing
- ./mvnw test *(fails: unable to download Maven wrapper due to network restrictions)*
- mvn test *(fails: cannot reach Maven Central to resolve Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68d334b5ff3c83258672f4f794f0aa55