### PR TITLE
Add client-side language switcher for UI

### DIFF
--- a/src/main/resources/static/css/styles.css
+++ b/src/main/resources/static/css/styles.css
@@ -42,8 +42,56 @@ body {
     flex-wrap: wrap;
 }
 
+.header-controls {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+
 .header-text {
     text-align: left;
+}
+
+.language-switcher {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: rgba(93, 95, 239, 0.08);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 0.3rem 0.6rem;
+}
+
+.language-button {
+    border: none;
+    background: none;
+    color: var(--muted);
+    font-weight: 600;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.language-button:hover,
+.language-button:focus {
+    color: var(--primary);
+    outline: none;
+}
+
+.language-button[aria-pressed="true"] {
+    background: var(--primary);
+    color: #fff;
+}
+
+body.dark-mode .language-switcher {
+    background: rgba(139, 141, 252, 0.18);
+}
+
+body.dark-mode .language-button[aria-pressed="true"] {
+    color: #111827;
 }
 
 .theme-toggle {
@@ -347,6 +395,15 @@ body.dark-mode .suggestion {
 
     .header-text {
         text-align: center;
+    }
+
+    .header-controls {
+        justify-content: center;
+    }
+
+    .language-switcher {
+        width: 100%;
+        justify-content: center;
     }
 
     .theme-toggle {

--- a/src/main/resources/static/js/i18n.js
+++ b/src/main/resources/static/js/i18n.js
@@ -1,0 +1,339 @@
+(function () {
+    const storageKey = 'animeai-language';
+    const defaultLanguage = 'pt';
+    const supportedLanguages = new Set(['pt', 'en', 'es']);
+
+    const translations = {
+        pt: {
+            'language.portuguese': 'Português',
+            'language.english': 'Inglês',
+            'language.spanish': 'Espanhol',
+            'language.switcher.label': 'Seleção de idioma',
+            'theme.toggle.title': 'Alternar tema',
+            'theme.toggle.light': 'Modo claro',
+            'theme.toggle.dark': 'Modo escuro',
+            'list.meta.title': 'AnimeAI - Catálogo de Animes',
+            'list.header.description': 'Gerencie sua coleção de animes e peça sugestões personalizadas.',
+            'list.actions.new': 'Cadastrar novo anime',
+            'list.actions.suggestion': 'Quero uma sugestão',
+            'list.section.title': 'Meus animes',
+            'list.table.title': 'Título',
+            'list.table.category': 'Categoria',
+            'list.table.releaseYear': 'Ano de lançamento',
+            'list.table.episodes': 'Episódios',
+            'list.table.actions': 'Ações',
+            'list.table.edit': 'Editar',
+            'list.table.delete': 'Excluir',
+            'list.confirm.delete': 'Tem certeza que deseja remover este anime?',
+            'list.empty': 'Nenhum anime cadastrado até o momento.',
+            'layout.footer': 'AnimeAI — Powered by Spring Boot e Thymeleaf.',
+            'form.meta.title.new': 'Cadastrar anime',
+            'form.meta.title.edit': 'Editar anime',
+            'form.header.title.new': 'Cadastrar anime',
+            'form.header.title.edit': 'Editar anime',
+            'form.header.description': 'Preencha os dados abaixo e mantenha sua lista sempre atualizada.',
+            'form.field.title': 'Título',
+            'form.placeholder.title': 'Ex: Fullmetal Alchemist',
+            'form.field.category': 'Categoria',
+            'form.select.placeholder': 'Selecione',
+            'form.field.releaseYear': 'Ano de lançamento',
+            'form.field.episodes': 'Número de episódios',
+            'form.placeholder.episodes': 'Ex: 24',
+            'form.actions.save': 'Salvar',
+            'form.actions.cancel': 'Cancelar',
+            'suggestion.meta.title': 'Sugestões de animes',
+            'suggestion.header.title': 'Sugestão personalizada',
+            'suggestion.header.description': 'Baseado na sua lista atual, aqui estão algumas recomendações.',
+            'suggestion.section.title': 'Resultado',
+            'suggestion.actions.back': 'Voltar para a lista'
+        },
+        en: {
+            'language.portuguese': 'Portuguese',
+            'language.english': 'English',
+            'language.spanish': 'Spanish',
+            'language.switcher.label': 'Language selection',
+            'theme.toggle.title': 'Toggle theme',
+            'theme.toggle.light': 'Light mode',
+            'theme.toggle.dark': 'Dark mode',
+            'list.meta.title': 'AnimeAI - Anime Catalog',
+            'list.header.description': 'Manage your anime collection and request personalized suggestions.',
+            'list.actions.new': 'Add new anime',
+            'list.actions.suggestion': 'Give me a suggestion',
+            'list.section.title': 'My anime',
+            'list.table.title': 'Title',
+            'list.table.category': 'Category',
+            'list.table.releaseYear': 'Release year',
+            'list.table.episodes': 'Episodes',
+            'list.table.actions': 'Actions',
+            'list.table.edit': 'Edit',
+            'list.table.delete': 'Delete',
+            'list.confirm.delete': 'Are you sure you want to remove this anime?',
+            'list.empty': 'No anime added yet.',
+            'layout.footer': 'AnimeAI — Powered by Spring Boot and Thymeleaf.',
+            'form.meta.title.new': 'Add anime',
+            'form.meta.title.edit': 'Edit anime',
+            'form.header.title.new': 'Add anime',
+            'form.header.title.edit': 'Edit anime',
+            'form.header.description': 'Fill out the information below to keep your list up to date.',
+            'form.field.title': 'Title',
+            'form.placeholder.title': 'e.g., Fullmetal Alchemist',
+            'form.field.category': 'Category',
+            'form.select.placeholder': 'Select',
+            'form.field.releaseYear': 'Release year',
+            'form.field.episodes': 'Number of episodes',
+            'form.placeholder.episodes': 'e.g., 24',
+            'form.actions.save': 'Save',
+            'form.actions.cancel': 'Cancel',
+            'suggestion.meta.title': 'Anime suggestions',
+            'suggestion.header.title': 'Personalized suggestion',
+            'suggestion.header.description': 'Based on your current list, here are some recommendations.',
+            'suggestion.section.title': 'Result',
+            'suggestion.actions.back': 'Back to the list'
+        },
+        es: {
+            'language.portuguese': 'Portugués',
+            'language.english': 'Inglés',
+            'language.spanish': 'Español',
+            'language.switcher.label': 'Selección de idioma',
+            'theme.toggle.title': 'Cambiar tema',
+            'theme.toggle.light': 'Modo claro',
+            'theme.toggle.dark': 'Modo oscuro',
+            'list.meta.title': 'AnimeAI - Catálogo de anime',
+            'list.header.description': 'Administra tu colección de anime y solicita sugerencias personalizadas.',
+            'list.actions.new': 'Agregar nuevo anime',
+            'list.actions.suggestion': 'Quiero una sugerencia',
+            'list.section.title': 'Mis animes',
+            'list.table.title': 'Título',
+            'list.table.category': 'Categoría',
+            'list.table.releaseYear': 'Año de lanzamiento',
+            'list.table.episodes': 'Episodios',
+            'list.table.actions': 'Acciones',
+            'list.table.edit': 'Editar',
+            'list.table.delete': 'Eliminar',
+            'list.confirm.delete': '¿Seguro que deseas eliminar este anime?',
+            'list.empty': 'No hay animes registrados por ahora.',
+            'layout.footer': 'AnimeAI — Impulsado por Spring Boot y Thymeleaf.',
+            'form.meta.title.new': 'Registrar anime',
+            'form.meta.title.edit': 'Editar anime',
+            'form.header.title.new': 'Registrar anime',
+            'form.header.title.edit': 'Editar anime',
+            'form.header.description': 'Completa los datos a continuación y mantén tu lista siempre actualizada.',
+            'form.field.title': 'Título',
+            'form.placeholder.title': 'Ej: Fullmetal Alchemist',
+            'form.field.category': 'Categoría',
+            'form.select.placeholder': 'Selecciona',
+            'form.field.releaseYear': 'Año de lanzamiento',
+            'form.field.episodes': 'Número de episodios',
+            'form.placeholder.episodes': 'Ej: 24',
+            'form.actions.save': 'Guardar',
+            'form.actions.cancel': 'Cancelar',
+            'suggestion.meta.title': 'Sugerencias de anime',
+            'suggestion.header.title': 'Sugerencia personalizada',
+            'suggestion.header.description': 'Con base en tu lista actual, aquí tienes algunas recomendaciones.',
+            'suggestion.section.title': 'Resultado',
+            'suggestion.actions.back': 'Volver a la lista'
+        }
+    };
+
+    let currentLanguage = defaultLanguage;
+
+    const translate = (key, lang = currentLanguage) => {
+        const languagePack = translations[lang];
+        if (languagePack && Object.prototype.hasOwnProperty.call(languagePack, key)) {
+            return languagePack[key];
+        }
+
+        if (lang !== defaultLanguage) {
+            const fallbackPack = translations[defaultLanguage];
+            if (fallbackPack && Object.prototype.hasOwnProperty.call(fallbackPack, key)) {
+                return fallbackPack[key];
+            }
+        }
+
+        return key;
+    };
+
+    const getStoredLanguage = () => {
+        try {
+            const stored = localStorage.getItem(storageKey);
+            if (stored && supportedLanguages.has(stored)) {
+                return stored;
+            }
+        } catch (error) {
+            // Ignored: storage might be unavailable.
+        }
+        return defaultLanguage;
+    };
+
+    const persistLanguage = (lang) => {
+        try {
+            localStorage.setItem(storageKey, lang);
+        } catch (error) {
+            // Ignored: storage might be unavailable.
+        }
+    };
+
+    const updateLanguageButtonsState = () => {
+        const buttons = document.querySelectorAll('.language-button[data-language]');
+        buttons.forEach((button) => {
+            const isActive = button.dataset.language === currentLanguage;
+            button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+        });
+    };
+
+    const updateThemeToggleLabels = () => {
+        const toggle = document.getElementById('theme-toggle');
+        if (!toggle) {
+            return;
+        }
+
+        const textElement = toggle.querySelector('.theme-toggle-text');
+        if (!textElement) {
+            return;
+        }
+
+        const lightKey = textElement.dataset.labelLightKey;
+        const darkKey = textElement.dataset.labelDarkKey;
+
+        if (lightKey) {
+            textElement.dataset.labelLight = translate(lightKey);
+        }
+        if (darkKey) {
+            textElement.dataset.labelDark = translate(darkKey);
+        }
+
+        const isDark = document.body.classList.contains('dark-mode');
+        const label = isDark ? textElement.dataset.labelLight : textElement.dataset.labelDark;
+        if (label) {
+            textElement.textContent = label;
+        }
+
+        const titleKey = toggle.dataset.i18nTitle;
+        if (titleKey) {
+            toggle.setAttribute('title', translate(titleKey));
+        }
+    };
+
+    const applyTranslations = () => {
+        const locale = currentLanguage === 'pt' ? 'pt-BR' : currentLanguage === 'es' ? 'es' : 'en';
+        document.documentElement.setAttribute('lang', locale);
+
+        const textElements = document.querySelectorAll('[data-i18n]');
+        textElements.forEach((element) => {
+            const key = element.dataset.i18n;
+            if (!key) {
+                return;
+            }
+            const value = translate(key);
+            element.textContent = value;
+        });
+
+        const placeholderElements = document.querySelectorAll('[data-i18n-placeholder]');
+        placeholderElements.forEach((element) => {
+            const key = element.dataset.i18nPlaceholder;
+            if (!key) {
+                return;
+            }
+            const value = translate(key);
+            element.setAttribute('placeholder', value);
+        });
+
+        const titleElements = document.querySelectorAll('[data-i18n-title]');
+        titleElements.forEach((element) => {
+            const key = element.dataset.i18nTitle;
+            if (!key) {
+                return;
+            }
+            element.setAttribute('title', translate(key));
+        });
+
+        const ariaLabelElements = document.querySelectorAll('[data-i18n-aria-label]');
+        ariaLabelElements.forEach((element) => {
+            const key = element.dataset.i18nAriaLabel;
+            if (!key) {
+                return;
+            }
+            element.setAttribute('aria-label', translate(key));
+        });
+
+        const documentTitleElement = document.querySelector('title[data-i18n-document-title]');
+        if (documentTitleElement) {
+            const key = documentTitleElement.dataset.i18nDocumentTitle;
+            if (key) {
+                document.title = translate(key);
+            }
+        }
+
+        updateThemeToggleLabels();
+        updateLanguageButtonsState();
+        document.dispatchEvent(new CustomEvent('animeai:languagechange', {
+            detail: { language: currentLanguage }
+        }));
+    };
+
+    const setLanguage = (lang, options = {}) => {
+        const desiredLanguage = supportedLanguages.has(lang) ? lang : defaultLanguage;
+        const shouldPersist = options.persist !== false;
+        const force = options.force === true;
+
+        if (!force && desiredLanguage === currentLanguage) {
+            updateLanguageButtonsState();
+            return;
+        }
+
+        currentLanguage = desiredLanguage;
+
+        if (shouldPersist) {
+            persistLanguage(currentLanguage);
+        }
+
+        applyTranslations();
+    };
+
+    const handleLanguageButtonClick = (event) => {
+        const button = event.currentTarget;
+        const lang = button.dataset.language;
+        setLanguage(lang);
+    };
+
+    const bindLanguageButtons = () => {
+        const buttons = document.querySelectorAll('.language-button[data-language]');
+        buttons.forEach((button) => {
+            button.addEventListener('click', handleLanguageButtonClick);
+        });
+    };
+
+    const setupDeleteConfirmation = () => {
+        const buttons = document.querySelectorAll('.js-delete-button[data-confirm-key]');
+        buttons.forEach((button) => {
+            if (button.dataset.confirmListenerAttached === 'true') {
+                return;
+            }
+            button.dataset.confirmListenerAttached = 'true';
+
+            button.addEventListener('click', (event) => {
+                const key = button.dataset.confirmKey;
+                const message = translate(key);
+                if (!message) {
+                    return;
+                }
+                if (!window.confirm(message)) {
+                    event.preventDefault();
+                }
+            });
+        });
+    };
+
+    document.addEventListener('DOMContentLoaded', () => {
+        window.AnimeAI = window.AnimeAI || {};
+        window.AnimeAI.translate = translate;
+        window.AnimeAI.setLanguage = (lang) => setLanguage(lang);
+        window.AnimeAI.getLanguage = () => currentLanguage;
+
+        currentLanguage = getStoredLanguage();
+
+        bindLanguageButtons();
+        setupDeleteConfirmation();
+        setLanguage(currentLanguage, { persist: false, force: true });
+    });
+})();

--- a/src/main/resources/static/js/theme.js
+++ b/src/main/resources/static/js/theme.js
@@ -10,6 +10,15 @@
     const icon = toggle.querySelector('.theme-toggle-icon');
     const text = toggle.querySelector('.theme-toggle-text');
 
+    const getToggleLabel = (isDarkMode) => {
+        if (!text) {
+            return '';
+        }
+
+        const datasetKey = isDarkMode ? 'labelLight' : 'labelDark';
+        return text.dataset[datasetKey] || text.textContent || '';
+    };
+
     const applyTheme = (theme) => {
         const isDark = theme === 'dark';
         body.classList.toggle('dark-mode', isDark);
@@ -20,7 +29,7 @@
         }
 
         if (text) {
-            text.textContent = isDark ? 'Modo claro' : 'Modo escuro';
+            text.textContent = getToggleLabel(isDark);
         }
     };
 

--- a/src/main/resources/templates/animes/form.html
+++ b/src/main/resources/templates/animes/form.html
@@ -2,56 +2,71 @@
 <html lang="pt-BR" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title th:text="${anime.id == null} ? 'Cadastrar anime' : 'Editar anime'"></title>
+    <title th:text="${anime.id == null} ? 'Cadastrar anime' : 'Editar anime'"
+           th:attr="data-i18n-document-title=${anime.id == null} ? 'form.meta.title.new' : 'form.meta.title.edit'"></title>
     <link rel="stylesheet" th:href="@{/css/styles.css}">
 </head>
 <body>
 <header class="page-header">
     <div class="container header-layout">
         <div class="header-text">
-            <h1 th:text="${anime.id == null} ? 'Cadastrar anime' : 'Editar anime'"></h1>
-            <p>Preencha os dados abaixo e mantenha sua lista sempre atualizada.</p>
+            <h1 th:text="${anime.id == null} ? 'Cadastrar anime' : 'Editar anime'"
+                th:attr="data-i18n=${anime.id == null} ? 'form.header.title.new' : 'form.header.title.edit'"></h1>
+            <p data-i18n="form.header.description">Preencha os dados abaixo e mantenha sua lista sempre atualizada.</p>
         </div>
-        <button id="theme-toggle" class="theme-toggle" type="button" aria-pressed="false" title="Alternar tema">
-            <span class="theme-toggle-icon" aria-hidden="true">🌙</span>
-            <span class="theme-toggle-text">Modo escuro</span>
-        </button>
+        <div class="header-controls">
+            <div class="language-switcher" role="group" data-i18n-aria-label="language.switcher.label" aria-label="Seleção de idioma">
+                <button type="button" class="language-button" data-language="pt" data-i18n="language.portuguese" aria-pressed="true">Português</button>
+                <button type="button" class="language-button" data-language="en" data-i18n="language.english">Inglês</button>
+                <button type="button" class="language-button" data-language="es" data-i18n="language.spanish">Espanhol</button>
+            </div>
+            <button id="theme-toggle" class="theme-toggle" type="button" aria-pressed="false" data-i18n-title="theme.toggle.title" title="Alternar tema">
+                <span class="theme-toggle-icon" aria-hidden="true">🌙</span>
+                <span class="theme-toggle-text"
+                      data-i18n="theme.toggle.dark"
+                      data-label-dark="Modo escuro"
+                      data-label-dark-key="theme.toggle.dark"
+                      data-label-light="Modo claro"
+                      data-label-light-key="theme.toggle.light">Modo escuro</span>
+            </button>
+        </div>
     </div>
 </header>
 <main class="container">
     <section class="card">
         <form class="anime-form" th:action="${anime.id} != null ? @{/animes/{id}/update(id=${anime.id})} : @{/animes}" th:object="${anime}" method="post">
             <div class="form-group">
-                <label for="titulo">Título</label>
-                <input id="titulo" type="text" th:field="*{titulo}" placeholder="Ex: Fullmetal Alchemist" required>
+                <label for="titulo" data-i18n="form.field.title">Título</label>
+                <input id="titulo" type="text" th:field="*{titulo}" placeholder="Ex: Fullmetal Alchemist" data-i18n-placeholder="form.placeholder.title" required>
             </div>
             <div class="form-group">
-                <label for="categoria">Categoria</label>
+                <label for="categoria" data-i18n="form.field.category">Categoria</label>
                 <select id="categoria" th:field="*{categoria}">
-                    <option value="" th:if="${anime.categoria == null}" disabled selected>Selecione</option>
+                    <option value="" th:if="${anime.categoria == null}" disabled selected data-i18n="form.select.placeholder">Selecione</option>
                     <option th:each="categoria : ${categorias}" th:value="${categoria}" th:text="${categoria}"></option>
                 </select>
             </div>
             <div class="form-group">
-                <label for="anoLancamento">Ano de lançamento</label>
+                <label for="anoLancamento" data-i18n="form.field.releaseYear">Ano de lançamento</label>
                 <input id="anoLancamento" type="date" th:field="*{anoLancamento}">
             </div>
             <div class="form-group">
-                <label for="numEpisodios">Número de episódios</label>
-                <input id="numEpisodios" type="number" min="1" th:field="*{numEpisodios}" placeholder="Ex: 24">
+                <label for="numEpisodios" data-i18n="form.field.episodes">Número de episódios</label>
+                <input id="numEpisodios" type="number" min="1" th:field="*{numEpisodios}" placeholder="Ex: 24" data-i18n-placeholder="form.placeholder.episodes">
             </div>
             <div class="form-actions">
-                <button type="submit" class="button">Salvar</button>
-                <a class="button secondary" th:href="@{/animes}">Cancelar</a>
+                <button type="submit" class="button" data-i18n="form.actions.save">Salvar</button>
+                <a class="button secondary" th:href="@{/animes}" data-i18n="form.actions.cancel">Cancelar</a>
             </div>
         </form>
     </section>
 </main>
 <footer class="page-footer">
     <div class="container">
-        <p>AnimeAI &mdash; Powered by Spring Boot e Thymeleaf.</p>
+        <p data-i18n="layout.footer">AnimeAI &mdash; Powered by Spring Boot e Thymeleaf.</p>
     </div>
 </footer>
+<script th:src="@{/js/i18n.js}"></script>
 <script th:src="@{/js/theme.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/animes/list.html
+++ b/src/main/resources/templates/animes/list.html
@@ -2,7 +2,7 @@
 <html lang="pt-BR" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>AnimeAI - Catálogo de Animes</title>
+    <title data-i18n-document-title="list.meta.title">AnimeAI - Catálogo de Animes</title>
     <link rel="stylesheet" th:href="@{/css/styles.css}">
 </head>
 <body>
@@ -10,12 +10,24 @@
     <div class="container header-layout">
         <div class="header-text">
             <h1>AnimeAI</h1>
-            <p>Gerencie sua coleção de animes e peça sugestões personalizadas.</p>
+            <p data-i18n="list.header.description">Gerencie sua coleção de animes e peça sugestões personalizadas.</p>
         </div>
-        <button id="theme-toggle" class="theme-toggle" type="button" aria-pressed="false" title="Alternar tema">
-            <span class="theme-toggle-icon" aria-hidden="true">🌙</span>
-            <span class="theme-toggle-text">Modo escuro</span>
-        </button>
+        <div class="header-controls">
+            <div class="language-switcher" role="group" data-i18n-aria-label="language.switcher.label" aria-label="Seleção de idioma">
+                <button type="button" class="language-button" data-language="pt" data-i18n="language.portuguese" aria-pressed="true">Português</button>
+                <button type="button" class="language-button" data-language="en" data-i18n="language.english">Inglês</button>
+                <button type="button" class="language-button" data-language="es" data-i18n="language.spanish">Espanhol</button>
+            </div>
+            <button id="theme-toggle" class="theme-toggle" type="button" aria-pressed="false" data-i18n-title="theme.toggle.title" title="Alternar tema">
+                <span class="theme-toggle-icon" aria-hidden="true">🌙</span>
+                <span class="theme-toggle-text"
+                      data-i18n="theme.toggle.dark"
+                      data-label-dark="Modo escuro"
+                      data-label-dark-key="theme.toggle.dark"
+                      data-label-light="Modo claro"
+                      data-label-light-key="theme.toggle.light">Modo escuro</span>
+            </button>
+        </div>
     </div>
 </header>
 <main class="container">
@@ -23,21 +35,21 @@
     <div th:if="${errorMessage}" class="alert error" th:text="${errorMessage}"></div>
 
     <div class="actions">
-        <a class="button" th:href="@{/animes/new}">Cadastrar novo anime</a>
-        <a class="button secondary" th:href="@{/animes/suggestion}">Quero uma sugestão</a>
+        <a class="button" th:href="@{/animes/new}" data-i18n="list.actions.new">Cadastrar novo anime</a>
+        <a class="button secondary" th:href="@{/animes/suggestion}" data-i18n="list.actions.suggestion">Quero uma sugestão</a>
     </div>
 
     <section class="card">
-        <h2>Meus animes</h2>
+        <h2 data-i18n="list.section.title">Meus animes</h2>
         <div class="table-responsive">
             <table class="anime-table">
                 <thead>
                 <tr>
-                    <th>Título</th>
-                    <th>Categoria</th>
-                    <th>Ano de lançamento</th>
-                    <th>Episódios</th>
-                    <th class="actions-header">Ações</th>
+                    <th data-i18n="list.table.title">Título</th>
+                    <th data-i18n="list.table.category">Categoria</th>
+                    <th data-i18n="list.table.releaseYear">Ano de lançamento</th>
+                    <th data-i18n="list.table.episodes">Episódios</th>
+                    <th class="actions-header" data-i18n="list.table.actions">Ações</th>
                 </tr>
                 </thead>
                 <tbody>
@@ -47,14 +59,14 @@
                     <td th:text="${anime.anoLancamento != null ? #temporals.format(anime.anoLancamento, 'dd/MM/yyyy') : '—'}"></td>
                     <td th:text="${anime.numEpisodios != null ? anime.numEpisodios : '—'}"></td>
                     <td class="actions-cell">
-                        <a class="button small secondary" th:href="@{/animes/{id}/edit(id=${anime.id})}">Editar</a>
+                        <a class="button small secondary" th:href="@{/animes/{id}/edit(id=${anime.id})}" data-i18n="list.table.edit">Editar</a>
                         <form th:action="@{/animes/{id}/delete(id=${anime.id})}" method="post" class="inline-form">
-                            <button type="submit" class="button small danger" onclick="return confirm('Tem certeza que deseja remover este anime?');">Excluir</button>
+                            <button type="submit" class="button small danger js-delete-button" data-confirm-key="list.confirm.delete" data-i18n="list.table.delete">Excluir</button>
                         </form>
                     </td>
                 </tr>
                 <tr th:if="${#lists.isEmpty(animes)}">
-                    <td colspan="5" class="empty-state">Nenhum anime cadastrado até o momento.</td>
+                    <td colspan="5" class="empty-state" data-i18n="list.empty">Nenhum anime cadastrado até o momento.</td>
                 </tr>
                 </tbody>
             </table>
@@ -63,9 +75,10 @@
 </main>
 <footer class="page-footer">
     <div class="container">
-        <p>AnimeAI &mdash; Powered by Spring Boot e Thymeleaf.</p>
+        <p data-i18n="layout.footer">AnimeAI &mdash; Powered by Spring Boot e Thymeleaf.</p>
     </div>
 </footer>
+<script th:src="@{/js/i18n.js}"></script>
 <script th:src="@{/js/theme.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/animes/suggestion.html
+++ b/src/main/resources/templates/animes/suggestion.html
@@ -2,36 +2,49 @@
 <html lang="pt-BR" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>Sugestões de animes</title>
+    <title data-i18n-document-title="suggestion.meta.title">Sugestões de animes</title>
     <link rel="stylesheet" th:href="@{/css/styles.css}">
 </head>
 <body>
 <header class="page-header">
     <div class="container header-layout">
         <div class="header-text">
-            <h1>Sugestão personalizada</h1>
-            <p>Baseado na sua lista atual, aqui estão algumas recomendações.</p>
+            <h1 data-i18n="suggestion.header.title">Sugestão personalizada</h1>
+            <p data-i18n="suggestion.header.description">Baseado na sua lista atual, aqui estão algumas recomendações.</p>
         </div>
-        <button id="theme-toggle" class="theme-toggle" type="button" aria-pressed="false" title="Alternar tema">
-            <span class="theme-toggle-icon" aria-hidden="true">🌙</span>
-            <span class="theme-toggle-text">Modo escuro</span>
-        </button>
+        <div class="header-controls">
+            <div class="language-switcher" role="group" data-i18n-aria-label="language.switcher.label" aria-label="Seleção de idioma">
+                <button type="button" class="language-button" data-language="pt" data-i18n="language.portuguese" aria-pressed="true">Português</button>
+                <button type="button" class="language-button" data-language="en" data-i18n="language.english">Inglês</button>
+                <button type="button" class="language-button" data-language="es" data-i18n="language.spanish">Espanhol</button>
+            </div>
+            <button id="theme-toggle" class="theme-toggle" type="button" aria-pressed="false" data-i18n-title="theme.toggle.title" title="Alternar tema">
+                <span class="theme-toggle-icon" aria-hidden="true">🌙</span>
+                <span class="theme-toggle-text"
+                      data-i18n="theme.toggle.dark"
+                      data-label-dark="Modo escuro"
+                      data-label-dark-key="theme.toggle.dark"
+                      data-label-light="Modo claro"
+                      data-label-light-key="theme.toggle.light">Modo escuro</span>
+            </button>
+        </div>
     </div>
 </header>
 <main class="container">
     <section class="card">
-        <h2>Resultado</h2>
+        <h2 data-i18n="suggestion.section.title">Resultado</h2>
         <pre class="suggestion" th:text="${suggestion}"></pre>
         <div class="form-actions">
-            <a class="button" th:href="@{/animes}">Voltar para a lista</a>
+            <a class="button" th:href="@{/animes}" data-i18n="suggestion.actions.back">Voltar para a lista</a>
         </div>
     </section>
 </main>
 <footer class="page-footer">
     <div class="container">
-        <p>AnimeAI &mdash; Powered by Spring Boot e Thymeleaf.</p>
+        <p data-i18n="layout.footer">AnimeAI &mdash; Powered by Spring Boot e Thymeleaf.</p>
     </div>
 </footer>
+<script th:src="@{/js/i18n.js}"></script>
 <script th:src="@{/js/theme.js}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a reusable language switcher to every anime page with Portuguese, English and Spanish options
- introduce a client-side i18n layer that translates UI text, updates the theme toggle label and stores the selected language
- adjust styles and the theme toggle script to accommodate the new controls and localized messaging

## Testing
- ./mvnw test *(fails: unable to download Maven wrapper distribution in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d465296658832595c93b5896570abe