### PR TITLE
Add Japanese locale, flag icons, and Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:1
+
+FROM maven:3.9.9-eclipse-temurin-17 AS build
+WORKDIR /workspace
+COPY pom.xml .
+COPY src ./src
+RUN mvn -q -DskipTests package
+
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=build /workspace/target/*.jar app.jar
+RUN mkdir -p /app/data
+VOLUME ["/app/data"]
+EXPOSE 8080
+ENV JAVA_OPTS=""
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.9"
+
+services:
+  animeai:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+    volumes:
+      - ./data:/app/data
+    restart: unless-stopped

--- a/src/main/resources/static/css/styles.css
+++ b/src/main/resources/static/css/styles.css
@@ -65,6 +65,9 @@ body {
 }
 
 .language-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
     border: none;
     background: none;
     color: var(--muted);
@@ -73,6 +76,15 @@ body {
     border-radius: 999px;
     cursor: pointer;
     transition: background 0.2s ease, color 0.2s ease;
+}
+
+.language-flag {
+    font-size: 1.1rem;
+    line-height: 1;
+}
+
+.language-label {
+    font-size: 0.95rem;
 }
 
 .language-button:hover,

--- a/src/main/resources/static/js/i18n.js
+++ b/src/main/resources/static/js/i18n.js
@@ -1,13 +1,20 @@
 (function () {
     const storageKey = 'animeai-language';
     const defaultLanguage = 'pt';
-    const supportedLanguages = new Set(['pt', 'en', 'es']);
+    const supportedLanguages = new Set(['pt', 'en', 'es', 'ja']);
+    const localeMap = {
+        pt: 'pt-BR',
+        en: 'en',
+        es: 'es',
+        ja: 'ja'
+    };
 
     const translations = {
         pt: {
             'language.portuguese': 'Português',
             'language.english': 'Inglês',
             'language.spanish': 'Espanhol',
+            'language.japanese': 'Japonês',
             'language.switcher.label': 'Seleção de idioma',
             'theme.toggle.title': 'Alternar tema',
             'theme.toggle.light': 'Modo claro',
@@ -51,6 +58,7 @@
             'language.portuguese': 'Portuguese',
             'language.english': 'English',
             'language.spanish': 'Spanish',
+            'language.japanese': 'Japanese',
             'language.switcher.label': 'Language selection',
             'theme.toggle.title': 'Toggle theme',
             'theme.toggle.light': 'Light mode',
@@ -94,6 +102,7 @@
             'language.portuguese': 'Portugués',
             'language.english': 'Inglés',
             'language.spanish': 'Español',
+            'language.japanese': 'Japonés',
             'language.switcher.label': 'Selección de idioma',
             'theme.toggle.title': 'Cambiar tema',
             'theme.toggle.light': 'Modo claro',
@@ -132,6 +141,50 @@
             'suggestion.header.description': 'Con base en tu lista actual, aquí tienes algunas recomendaciones.',
             'suggestion.section.title': 'Resultado',
             'suggestion.actions.back': 'Volver a la lista'
+        },
+        ja: {
+            'language.portuguese': 'ポルトガル語',
+            'language.english': '英語',
+            'language.spanish': 'スペイン語',
+            'language.japanese': '日本語',
+            'language.switcher.label': '言語の選択',
+            'theme.toggle.title': 'テーマを切り替える',
+            'theme.toggle.light': 'ライトモード',
+            'theme.toggle.dark': 'ダークモード',
+            'list.meta.title': 'AnimeAI - アニメカタログ',
+            'list.header.description': 'アニメコレクションを管理して、あなたに合わせたおすすめを受け取りましょう。',
+            'list.actions.new': '新しいアニメを登録',
+            'list.actions.suggestion': 'おすすめが欲しい',
+            'list.section.title': 'マイアニメ',
+            'list.table.title': 'タイトル',
+            'list.table.category': 'カテゴリー',
+            'list.table.releaseYear': '公開年',
+            'list.table.episodes': 'エピソード数',
+            'list.table.actions': '操作',
+            'list.table.edit': '編集',
+            'list.table.delete': '削除',
+            'list.confirm.delete': 'このアニメを削除してもよろしいですか？',
+            'list.empty': 'まだアニメが登録されていません。',
+            'layout.footer': 'AnimeAI — Spring Boot と Thymeleaf で動作しています。',
+            'form.meta.title.new': 'アニメを登録',
+            'form.meta.title.edit': 'アニメを編集',
+            'form.header.title.new': 'アニメを登録',
+            'form.header.title.edit': 'アニメを編集',
+            'form.header.description': '以下の情報を入力して、リストを常に最新の状態に保ちましょう。',
+            'form.field.title': 'タイトル',
+            'form.placeholder.title': '例: 鋼の錬金術師',
+            'form.field.category': 'カテゴリー',
+            'form.select.placeholder': '選択してください',
+            'form.field.releaseYear': '公開年',
+            'form.field.episodes': 'エピソード数',
+            'form.placeholder.episodes': '例: 24',
+            'form.actions.save': '保存',
+            'form.actions.cancel': 'キャンセル',
+            'suggestion.meta.title': 'アニメのおすすめ',
+            'suggestion.header.title': 'パーソナライズされたおすすめ',
+            'suggestion.header.description': '現在のリストに基づき、いくつかのおすすめをご紹介します。',
+            'suggestion.section.title': '結果',
+            'suggestion.actions.back': '一覧に戻る'
         }
     };
 
@@ -215,7 +268,7 @@
     };
 
     const applyTranslations = () => {
-        const locale = currentLanguage === 'pt' ? 'pt-BR' : currentLanguage === 'es' ? 'es' : 'en';
+        const locale = localeMap[currentLanguage] || currentLanguage;
         document.documentElement.setAttribute('lang', locale);
 
         const textElements = document.querySelectorAll('[data-i18n]');

--- a/src/main/resources/templates/animes/form.html
+++ b/src/main/resources/templates/animes/form.html
@@ -16,9 +16,22 @@
         </div>
         <div class="header-controls">
             <div class="language-switcher" role="group" data-i18n-aria-label="language.switcher.label" aria-label="Seleção de idioma">
-                <button type="button" class="language-button" data-language="pt" data-i18n="language.portuguese" aria-pressed="true">Português</button>
-                <button type="button" class="language-button" data-language="en" data-i18n="language.english">Inglês</button>
-                <button type="button" class="language-button" data-language="es" data-i18n="language.spanish">Espanhol</button>
+                <button type="button" class="language-button" data-language="pt" aria-pressed="true">
+                    <span class="language-flag" aria-hidden="true">🇧🇷</span>
+                    <span class="language-label" data-i18n="language.portuguese">Português</span>
+                </button>
+                <button type="button" class="language-button" data-language="en">
+                    <span class="language-flag" aria-hidden="true">🇺🇸</span>
+                    <span class="language-label" data-i18n="language.english">Inglês</span>
+                </button>
+                <button type="button" class="language-button" data-language="es">
+                    <span class="language-flag" aria-hidden="true">🇪🇸</span>
+                    <span class="language-label" data-i18n="language.spanish">Espanhol</span>
+                </button>
+                <button type="button" class="language-button" data-language="ja">
+                    <span class="language-flag" aria-hidden="true">🇯🇵</span>
+                    <span class="language-label" data-i18n="language.japanese">Japonês</span>
+                </button>
             </div>
             <button id="theme-toggle" class="theme-toggle" type="button" aria-pressed="false" data-i18n-title="theme.toggle.title" title="Alternar tema">
                 <span class="theme-toggle-icon" aria-hidden="true">🌙</span>

--- a/src/main/resources/templates/animes/list.html
+++ b/src/main/resources/templates/animes/list.html
@@ -14,9 +14,22 @@
         </div>
         <div class="header-controls">
             <div class="language-switcher" role="group" data-i18n-aria-label="language.switcher.label" aria-label="Seleção de idioma">
-                <button type="button" class="language-button" data-language="pt" data-i18n="language.portuguese" aria-pressed="true">Português</button>
-                <button type="button" class="language-button" data-language="en" data-i18n="language.english">Inglês</button>
-                <button type="button" class="language-button" data-language="es" data-i18n="language.spanish">Espanhol</button>
+                <button type="button" class="language-button" data-language="pt" aria-pressed="true">
+                    <span class="language-flag" aria-hidden="true">🇧🇷</span>
+                    <span class="language-label" data-i18n="language.portuguese">Português</span>
+                </button>
+                <button type="button" class="language-button" data-language="en">
+                    <span class="language-flag" aria-hidden="true">🇺🇸</span>
+                    <span class="language-label" data-i18n="language.english">Inglês</span>
+                </button>
+                <button type="button" class="language-button" data-language="es">
+                    <span class="language-flag" aria-hidden="true">🇪🇸</span>
+                    <span class="language-label" data-i18n="language.spanish">Espanhol</span>
+                </button>
+                <button type="button" class="language-button" data-language="ja">
+                    <span class="language-flag" aria-hidden="true">🇯🇵</span>
+                    <span class="language-label" data-i18n="language.japanese">Japonês</span>
+                </button>
             </div>
             <button id="theme-toggle" class="theme-toggle" type="button" aria-pressed="false" data-i18n-title="theme.toggle.title" title="Alternar tema">
                 <span class="theme-toggle-icon" aria-hidden="true">🌙</span>

--- a/src/main/resources/templates/animes/suggestion.html
+++ b/src/main/resources/templates/animes/suggestion.html
@@ -14,9 +14,22 @@
         </div>
         <div class="header-controls">
             <div class="language-switcher" role="group" data-i18n-aria-label="language.switcher.label" aria-label="Seleção de idioma">
-                <button type="button" class="language-button" data-language="pt" data-i18n="language.portuguese" aria-pressed="true">Português</button>
-                <button type="button" class="language-button" data-language="en" data-i18n="language.english">Inglês</button>
-                <button type="button" class="language-button" data-language="es" data-i18n="language.spanish">Espanhol</button>
+                <button type="button" class="language-button" data-language="pt" aria-pressed="true">
+                    <span class="language-flag" aria-hidden="true">🇧🇷</span>
+                    <span class="language-label" data-i18n="language.portuguese">Português</span>
+                </button>
+                <button type="button" class="language-button" data-language="en">
+                    <span class="language-flag" aria-hidden="true">🇺🇸</span>
+                    <span class="language-label" data-i18n="language.english">Inglês</span>
+                </button>
+                <button type="button" class="language-button" data-language="es">
+                    <span class="language-flag" aria-hidden="true">🇪🇸</span>
+                    <span class="language-label" data-i18n="language.spanish">Espanhol</span>
+                </button>
+                <button type="button" class="language-button" data-language="ja">
+                    <span class="language-flag" aria-hidden="true">🇯🇵</span>
+                    <span class="language-label" data-i18n="language.japanese">Japonês</span>
+                </button>
             </div>
             <button id="theme-toggle" class="theme-toggle" type="button" aria-pressed="false" data-i18n-title="theme.toggle.title" title="Alternar tema">
                 <span class="theme-toggle-icon" aria-hidden="true">🌙</span>


### PR DESCRIPTION
## Summary
- add flag icons to the language switcher and include a Japanese option across the Thymeleaf views
- extend the client-side i18n bundle with Japanese translations and locale handling
- introduce Dockerfile and docker-compose.yml to build and run the app in containers

## Testing
- ./mvnw test *(fails: unable to download Maven distribution because external network access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d467c163ec8325b6928cf456be2130