### PR TITLE
Refine dark theme styling and harden anime form validation

### DIFF
--- a/src/main/java/com/example/AnimeAI/controller/AnimeController.java
+++ b/src/main/java/com/example/AnimeAI/controller/AnimeController.java
@@ -10,9 +10,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -66,9 +66,13 @@ public class AnimeController {
     })
     public ResponseEntity<AnimeModel> findByTitulo(@Parameter(description = "Título completo do anime", example = "Naruto")
                                                    @PathVariable String titulo) {
-        Optional<AnimeModel> anime = animeService.findByTitulo(titulo);
-        return anime.map(ResponseEntity::ok)
-                .orElse(ResponseEntity.notFound().build());
+        try {
+            Optional<AnimeModel> anime = animeService.findByTitulo(titulo);
+            return anime.map(ResponseEntity::ok)
+                    .orElse(ResponseEntity.notFound().build());
+        } catch (IllegalArgumentException ex) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 
     @GetMapping("/categoria/{categoria}")
@@ -92,12 +96,14 @@ public class AnimeController {
                             schema = @Schema(implementation = AnimeModel.class))),
             @ApiResponse(responseCode = "400", description = "Requisição inválida", content = @Content)
     })
-    public ResponseEntity<AnimeModel> save(@Validated @RequestBody AnimeModel anime) {
+    public ResponseEntity<AnimeModel> save(@Valid @RequestBody AnimeModel anime) {
         try {
             AnimeModel animeSalvo = animeService.save(anime);
             return ResponseEntity.status(HttpStatus.CREATED).body(animeSalvo);
-        } catch (Exception e) {
+        } catch (IllegalArgumentException ex) {
             return ResponseEntity.badRequest().build();
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
     }
 
@@ -111,10 +117,14 @@ public class AnimeController {
     })
     public ResponseEntity<AnimeModel> updateById(@Parameter(description = "Identificador do anime", example = "1")
                                                  @PathVariable Long id,
-                                                 @Validated @RequestBody AnimeModel anime) {
-        Optional<AnimeModel> animeAtualizado = animeService.updateById(id, anime);
-        return animeAtualizado.map(ResponseEntity::ok)
-                .orElse(ResponseEntity.notFound().build());
+                                                 @Valid @RequestBody AnimeModel anime) {
+        try {
+            Optional<AnimeModel> animeAtualizado = animeService.updateById(id, anime);
+            return animeAtualizado.map(ResponseEntity::ok)
+                    .orElse(ResponseEntity.notFound().build());
+        } catch (IllegalArgumentException ex) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/example/AnimeAI/model/AnimeModel.java
+++ b/src/main/java/com/example/AnimeAI/model/AnimeModel.java
@@ -1,6 +1,11 @@
 package com.example.AnimeAI.model;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -18,14 +23,27 @@ public class AnimeModel {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @Column(nullable = false)
+    @Column(nullable = false, length = 120)
+    @NotBlank(message = "O título é obrigatório.")
+    @Size(max = 120, message = "O título deve ter no máximo {max} caracteres.")
+    @Pattern(regexp = "^[\\p{L}\\p{N}\\s\-'.,:;!?()]+$", message = "O título contém caracteres inválidos.")
     private String titulo;
     @Enumerated(EnumType.STRING)
     private Categoria categoria;
     @Column(name = "ano_lancamento")
     @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @PastOrPresent(message = "O ano de lançamento deve ser uma data válida no passado ou presente.")
     private LocalDate anoLancamento;
     @Column(name = "num_episodios")
+    @Positive(message = "O número de episódios deve ser maior que zero.")
     private Integer numEpisodios;
+
+    @PrePersist
+    @PreUpdate
+    private void normalizeFields() {
+        if (titulo != null) {
+            titulo = titulo.trim();
+        }
+    }
 
 }

--- a/src/main/java/com/example/AnimeAI/service/AnimeService.java
+++ b/src/main/java/com/example/AnimeAI/service/AnimeService.java
@@ -5,11 +5,19 @@ import com.example.AnimeAI.model.Categoria;
 import com.example.AnimeAI.repository.AnimeRepository;
 import org.springframework.stereotype.Service;
 
+import java.text.Normalizer;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 @Service
 public class AnimeService {
+
+    private static final Pattern SQL_INJECTION_PATTERN = Pattern.compile(
+            "(--|/\\*|\\*/|\\bOR\\b\\s+1\\s*=\\s*1|;\\s*(ALTER|DROP|INSERT|DELETE|UPDATE|SELECT|GRANT|REVOKE|UNION|CREATE)\\b|\\b(ALTER|DROP|INSERT|DELETE|UPDATE|SELECT|GRANT|REVOKE|UNION|CREATE)\\b)",
+            Pattern.CASE_INSENSITIVE
+    );
+    private static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s+");
 
     private final AnimeRepository repository;
 
@@ -26,7 +34,8 @@ public class AnimeService {
     }
 
     public Optional<AnimeModel> findByTitulo(String titulo){
-        return repository.findByTitulo(titulo);
+        String sanitizedTitulo = sanitizeTitulo(titulo);
+        return repository.findByTitulo(sanitizedTitulo);
     }
 
     public List<AnimeModel> findByCategoria(Categoria categoria){
@@ -34,10 +43,12 @@ public class AnimeService {
     }
 
     public AnimeModel save(AnimeModel animeModel){
+        sanitizeAnime(animeModel);
         return repository.save(animeModel);
     }
 
     public Optional<AnimeModel> updateById(Long id, AnimeModel animeAtualizado) {
+        sanitizeAnime(animeAtualizado);
         return repository.findById(id)
                 .map(anime -> {
                     anime.setTitulo(animeAtualizado.getTitulo());
@@ -54,6 +65,32 @@ public class AnimeService {
             return true;
         }
         return false;
+    }
+
+    private void sanitizeAnime(AnimeModel animeModel) {
+        if (animeModel == null) {
+            throw new IllegalArgumentException("Os dados do anime são obrigatórios.");
+        }
+        animeModel.setTitulo(sanitizeTitulo(animeModel.getTitulo()));
+    }
+
+    private String sanitizeTitulo(String rawTitulo) {
+        if (rawTitulo == null) {
+            throw new IllegalArgumentException("O título é obrigatório.");
+        }
+
+        String normalized = Normalizer.normalize(rawTitulo, Normalizer.Form.NFC).trim();
+        if (normalized.isEmpty()) {
+            throw new IllegalArgumentException("O título é obrigatório.");
+        }
+
+        normalized = WHITESPACE_PATTERN.matcher(normalized).replaceAll(" ");
+
+        if (SQL_INJECTION_PATTERN.matcher(normalized).find()) {
+            throw new IllegalArgumentException("O título contém termos potencialmente maliciosos.");
+        }
+
+        return normalized;
     }
 }
 

--- a/src/main/resources/static/css/styles.css
+++ b/src/main/resources/static/css/styles.css
@@ -13,13 +13,13 @@
 body.dark-mode {
     --primary: #8b8dfc;
     --primary-dark: #7375f8;
-    --background: #0f172a;
-    --surface: #1e293b;
-    --text: #e2e8f0;
-    --muted: #94a3b8;
+    --background: #050505;
+    --surface: #0f0f10;
+    --text: #f5f5f5;
+    --muted: #cbd5f5;
     --danger: #fca5a5;
     --success: #4ade80;
-    --border: #334155;
+    --border: #1f1f22;
 }
 
 * {
@@ -28,10 +28,24 @@ body.dark-mode {
 
 body {
     margin: 0;
-    font-family: "Inter", "Segoe UI", sans-serif;
+    font-family: "Inter", "Segoe UI", -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
     background: var(--background);
     color: var(--text);
-    line-height: 1.6;
+    line-height: 1.7;
+    font-size: 16px;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+}
+
+h1, h2, h3 {
+    font-weight: 700;
+    letter-spacing: -0.02em;
+}
+
+p {
+    color: var(--text);
+    font-size: 1.05rem;
+    max-width: 65ch;
 }
 
 .header-layout {
@@ -195,7 +209,7 @@ body.dark-mode .page-footer {
 
 .page-header h1 {
     margin: 0 0 0.5rem;
-    font-size: 2.4rem;
+    font-size: clamp(2.1rem, 4vw, 2.6rem);
     color: var(--primary);
 }
 
@@ -213,8 +227,8 @@ body.dark-mode .page-footer {
 }
 
 body.dark-mode .card {
-    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.65);
-    border: 1px solid rgba(148, 163, 184, 0.16);
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.8);
+    border: 1px solid rgba(148, 163, 184, 0.14);
 }
 
 .card h2 {
@@ -343,8 +357,12 @@ body.dark-mode .button.danger:hover {
     background: rgba(93, 95, 239, 0.05);
 }
 
+body.dark-mode .anime-table tbody tr {
+    background: rgba(15, 15, 16, 0.75);
+}
+
 body.dark-mode .anime-table tbody tr:hover {
-    background: rgba(139, 141, 252, 0.1);
+    background: rgba(139, 141, 252, 0.16);
 }
 
 .actions-header,
@@ -381,6 +399,7 @@ body.dark-mode .anime-table tbody tr:hover {
 
 .form-group label {
     font-weight: 600;
+    color: var(--text);
 }
 
 .form-group input,
@@ -397,6 +416,33 @@ body.dark-mode .anime-table tbody tr:hover {
     outline: none;
     border-color: var(--primary);
     box-shadow: 0 0 0 3px rgba(93, 95, 239, 0.2);
+}
+
+body.dark-mode .form-group input,
+body.dark-mode .form-group select {
+    background: #111113;
+    color: var(--text);
+    border-color: #2d2d32;
+}
+
+body.dark-mode .form-group input:focus,
+body.dark-mode .form-group select:focus {
+    box-shadow: 0 0 0 3px rgba(115, 117, 248, 0.28);
+}
+
+.form-group .form-error {
+    margin: 0.25rem 0 0;
+    font-size: 0.875rem;
+    color: var(--danger);
+}
+
+.form-group.has-error label {
+    color: var(--danger);
+}
+
+.is-invalid {
+    border-color: var(--danger) !important;
+    box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.15) !important;
 }
 
 .form-actions {

--- a/src/main/resources/templates/animes/form.html
+++ b/src/main/resources/templates/animes/form.html
@@ -56,24 +56,29 @@
 <main class="container">
     <section class="card">
         <form class="anime-form" th:action="${anime.id} != null ? @{/animes/{id}/update(id=${anime.id})} : @{/animes}" th:object="${anime}" method="post">
-            <div class="form-group">
+            <input type="hidden" th:field="*{id}">
+            <div class="form-group" th:classappend="${#fields.hasErrors('titulo')} ? ' has-error' : ''">
                 <label for="titulo" data-i18n="form.field.title">Título</label>
-                <input id="titulo" type="text" th:field="*{titulo}" placeholder="Ex: Fullmetal Alchemist" data-i18n-placeholder="form.placeholder.title" required>
+                <input id="titulo" type="text" th:field="*{titulo}" placeholder="Ex: Fullmetal Alchemist" data-i18n-placeholder="form.placeholder.title" required th:classappend="${#fields.hasErrors('titulo')} ? ' is-invalid' : ''">
+                <p class="form-error" th:if="${#fields.hasErrors('titulo')}" th:errors="*{titulo}"></p>
             </div>
-            <div class="form-group">
+            <div class="form-group" th:classappend="${#fields.hasErrors('categoria')} ? ' has-error' : ''">
                 <label for="categoria" data-i18n="form.field.category">Categoria</label>
-                <select id="categoria" th:field="*{categoria}">
+                <select id="categoria" th:field="*{categoria}" th:classappend="${#fields.hasErrors('categoria')} ? ' is-invalid' : ''">
                     <option value="" th:if="${anime.categoria == null}" disabled selected data-i18n="form.select.placeholder">Selecione</option>
                     <option th:each="categoria : ${categorias}" th:value="${categoria}" th:text="${categoria}"></option>
                 </select>
+                <p class="form-error" th:if="${#fields.hasErrors('categoria')}" th:errors="*{categoria}"></p>
             </div>
-            <div class="form-group">
+            <div class="form-group" th:classappend="${#fields.hasErrors('anoLancamento')} ? ' has-error' : ''">
                 <label for="anoLancamento" data-i18n="form.field.releaseYear">Ano de lançamento</label>
-                <input id="anoLancamento" type="date" th:field="*{anoLancamento}">
+                <input id="anoLancamento" type="date" th:field="*{anoLancamento}" th:classappend="${#fields.hasErrors('anoLancamento')} ? ' is-invalid' : ''">
+                <p class="form-error" th:if="${#fields.hasErrors('anoLancamento')}" th:errors="*{anoLancamento}"></p>
             </div>
-            <div class="form-group">
+            <div class="form-group" th:classappend="${#fields.hasErrors('numEpisodios')} ? ' has-error' : ''">
                 <label for="numEpisodios" data-i18n="form.field.episodes">Número de episódios</label>
-                <input id="numEpisodios" type="number" min="1" th:field="*{numEpisodios}" placeholder="Ex: 24" data-i18n-placeholder="form.placeholder.episodes">
+                <input id="numEpisodios" type="number" min="1" th:field="*{numEpisodios}" placeholder="Ex: 24" data-i18n-placeholder="form.placeholder.episodes" th:classappend="${#fields.hasErrors('numEpisodios')} ? ' is-invalid' : ''">
+                <p class="form-error" th:if="${#fields.hasErrors('numEpisodios')}" th:errors="*{numEpisodios}"></p>
             </div>
             <div class="form-actions">
                 <button type="submit" class="button" data-i18n="form.actions.save">Salvar</button>


### PR DESCRIPTION
## Summary
- adjust the dark theme palette, typography defaults, and form styling to improve readability in light and dark modes
- add Bean Validation constraints and SQL-injection guards for anime titles together with safer REST responses
- surface server-side validation feedback in the Thymeleaf form, preserving the anime id during edits

## Testing
- `./mvnw test` *(fails: Maven wrapper cannot download Apache Maven binaries in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d483a2ccc08325b6a564d0d1d7c995