### PR TITLE
Centralize footer and improve action button layout

### DIFF
--- a/src/main/resources/static/css/styles.css
+++ b/src/main/resources/static/css/styles.css
@@ -232,6 +232,12 @@ body.dark-mode .page-footer {
     color: var(--muted);
 }
 
+.page-footer .container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
 .page-header h1 {
     margin: 0 0 0.5rem;
     font-size: clamp(2.1rem, 4vw, 2.6rem);
@@ -406,14 +412,27 @@ body.dark-mode .anime-table tbody tr:hover {
     text-align: right;
 }
 
-.inline-form {
-    display: inline;
-    margin: 0;
+.actions-cell {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
 }
 
-.inline-form button {
-    border: none;
-    background: none;
+.actions-cell > * {
+    display: inline-flex;
+}
+
+.actions-cell .button,
+.actions-cell .inline-form button {
+    min-width: 7.5rem;
+    justify-content: center;
+}
+
+.inline-form {
+    display: inline-flex;
+    margin: 0;
 }
 
 .empty-state {

--- a/src/main/resources/templates/animes/list.html
+++ b/src/main/resources/templates/animes/list.html
@@ -100,7 +100,7 @@
 </main>
 <footer class="page-footer">
     <div class="container">
-        <p data-i18n="layout.footer">AnimeAI &mdash; Powered by Spring Boot e Thymeleaf.</p>
+        <p>AnimeAI</p>
     </div>
 </footer>
 <script th:src="@{/js/i18n.js}"></script>


### PR DESCRIPTION
## Summary
- Center the footer content and trim it to show only the AnimeAI branding
- Align the edit and delete actions with consistent spacing and sizing for better responsiveness

## Testing
- ./mvnw -q -DskipTests package *(fails: wget was unable to download apache-maven-3.9.11-bin.zip due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d48d93d70c83258121bb9cd05541d8